### PR TITLE
Cleanup `Lift`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A lightweight functional programming library with
 - 🗒️ [docs]
 - 📁 [repository]
 
-[docs]:https://https://funprogram.readthedocs.io/en/latest/
+[docs]:https://funprogram.readthedocs.io/en/latest/
 [repository]:https://github.com/opeltre/fp
 [numpy]:https://numpy.org
 [jax]:https://jax.readthedocs.io/en/latest/

--- a/fp/cartesian/hom.py
+++ b/fp/cartesian/hom.py
@@ -19,8 +19,16 @@ class HomObject(Arrow.Object):
     tgt: Type
     arity: int
 
-    def __init__(self, pipe: Callable | tuple[Callable]):
-        # wrap callables in the monoidal tuple type
+    def __init__(self, pipe: Callable | tuple[Callable, ...]):
+        """Wrap callable(s) in the monoidal tuple type.
+
+        Tuples of callables are accepted in order to wrap function
+        compositions in a linear and monoidal data structure, but
+        passing a tuple as `pipe` argument manually is discouraged.
+        Multiple inputs / outputs are processed consistently
+        throughout the type using the `src`, `tgt` and `arity`
+        attributes of `Hom` objects.
+        """
         if isinstance(pipe, tuple):
             self._pipe = pipe
         elif callable(pipe) and self.arity == 1:
@@ -32,6 +40,7 @@ class HomObject(Arrow.Object):
             self.__name__ = pipe.__name__ if pipe.__name__ != "<lambda>" else "λ"
 
     def __call__(self, *xs) -> tgt:
+        """Evaluate morphism on inputs."""
 
         def pipe(x):
             for f in self._pipe:

--- a/fp/cartesian/hom.py
+++ b/fp/cartesian/hom.py
@@ -142,7 +142,7 @@ class HomObject(Arrow.Object):
             # n-ary call (on n typed inputs)
             return xs
 
-        if r == 0 and xs[0] == Type.Unit() or xs[0] is None:
+        if r == 0 and (len(xs) == 0 or xs[0] == Type.Unit() or xs[0] is None):
             # constant
             return Type.Unit()
 
@@ -282,8 +282,13 @@ class Hom(Arrow, metaclass=HomFunctor):
             f_xs.__name__ = f"{f.__name__} " + " ".join((str(x) for x in xs))
             return cls(src, f.tgt)(f_xs)
 
+        elif len(xs) == f.arity:
+            f_xs = functools.partial(f, *xs)
+            f_xs.__name__ = f"{f.__name__} " + " ".join((str(x) for x in xs))
+            return cls((), f.tgt)(f_xs)
+
         raise TypeError(
-            f"Cannot partially call {Arr.arity} function on " + f"{len(xs)}-ary input"
+            f"Cannot partially call {f.arity} function on " + f"{len(xs)}-ary input"
         )
 
     @classmethod

--- a/fp/cartesian/hom.py
+++ b/fp/cartesian/hom.py
@@ -150,7 +150,7 @@ class HomObject(Arrow.Object):
             return io.cast(xs, Src) if not isinstance(Src, Var) else xs
 
     @staticmethod
-    def target_type(arrow, xs, match=True):
+    def target_type(arrow, xs: tuple, match=True) -> Type:
         """
         Target type inference.
         """

--- a/fp/cartesian/hom.py
+++ b/fp/cartesian/hom.py
@@ -108,11 +108,14 @@ class HomObject(Arrow.Object):
         elif len(xs) == 1 and isinstance(xs[0], arrow.src):
             # n-ary call on Prod instance
             Src = arrow.src
-
-        else:
+        elif len(xs) <= arrow.arity:
             # partial call
             ts = arrow.src._tail_[: len(xs)]
             Src = Type.Prod(*ts)
+        else:
+            raise ValueError(
+                f"too many arguments for {arrow.src} -> {arrow.tgt} on {xs}"
+            )
 
         if not isinstance(Src, Var):
             # concrete type, True

--- a/fp/cartesian/hom.py
+++ b/fp/cartesian/hom.py
@@ -19,15 +19,16 @@ class HomObject(Arrow.Object):
     tgt: Type
     arity: int
 
+    # reference to Hom
+    _head_: HomFunctor
+
     def __init__(self, pipe: Callable | tuple[Callable, ...]):
         """Wrap callable(s) in the monoidal tuple type.
 
-        Tuples of callables are accepted in order to wrap function
-        compositions in a linear and monoidal data structure, but
-        passing a tuple as `pipe` argument manually is discouraged.
-        Multiple inputs / outputs are processed consistently
-        throughout the type using the `src`, `tgt` and `arity`
-        attributes of `Hom` objects.
+        Tuples of callables are used to wrap function compositions in a linear
+        and monoidal data structure. Multiple inputs / outputs are processed
+        consistently throughout the pipe using the `src`, `tgt` and `arity`
+        attributes of `Hom` objects, see :attr:`Hom.compose`.
         """
         if isinstance(pipe, tuple):
             self._pipe = pipe

--- a/fp/cartesian/prod.py
+++ b/fp/cartesian/prod.py
@@ -5,6 +5,9 @@ import fp.io as io
 
 class Prod(Type, metaclass=Functor):
 
+    src = Type
+    tgt = Type
+
     arity = ...
     _kind_ = ..., ()
 
@@ -28,7 +31,7 @@ class Prod(Type, metaclass=Functor):
         (Int, Str) : (4, '||||||||')
     """
 
-    class Object(tuple):
+    class Object(tuple, metaclass=Type):
         """
         Product base type: `tuple` alias.
         """
@@ -61,12 +64,19 @@ class Prod(Type, metaclass=Functor):
             if not isinstance(xs, P):
                 return P(*(io.cast(x, A) for A, x in zip(P._tail_, xs)))
 
+    @classmethod
+    def new(cls, *As):
+        return super().new(*As)
+
     def __init__(P, *As): ...
 
     def __getitem__(P, i: int | slice):
         if isinstance(i, int):
             return P._tail_[i]
         return P.__class__(*P._tail_[i])
+
+    def __len__(P):
+        return len(P._tail_)
 
     @classmethod
     def fmap(cls, *fs: Callable) -> Callable:

--- a/fp/instances/async_io.py
+++ b/fp/instances/async_io.py
@@ -79,7 +79,7 @@ class AsyncIO(Type, metaclass=Monad):
 
     @classmethod
     def new(cls, A):
-        IOA = super().new(cls, A)
+        IOA = super().new(A)
         IOA.src = Type.Unit
         IOA.tgt = A
         IOA._type_ = A

--- a/fp/instances/lifts.py
+++ b/fp/instances/lifts.py
@@ -2,7 +2,6 @@ from .struct import struct
 from fp.cartesian import Type, Hom, Either
 
 import typing
-from types import FunctionType
 
 
 @struct
@@ -135,13 +134,3 @@ class Lift:
             return getattr(x, self.name)(*xs)
 
         return raw_bound_method
-
-
-@struct
-class WrapLift(Lift):
-    from_source = lambda x: x.data
-
-
-@struct
-class ProdLift(Lift):
-    from_source = lambda x: x[0]

--- a/fp/instances/lifts.py
+++ b/fp/instances/lifts.py
@@ -4,7 +4,6 @@ from fp.cartesian import Type, Hom, Either
 import typing
 
 
-@struct
 class Lift:
     """
     Declarative definition of method lifts.
@@ -57,15 +56,20 @@ class Lift:
         managed by `__set_attr__`
     """
 
-    signature: Either(int, typing.Callable)
-    # override default lift for each functor
     from_source: typing.Callable = lambda x: x
     to_target: typing.Callable = lambda y: y
-    #
-    lift_args: Either(type(...), int, tuple) = ...
-    flip: int = 0
-    # manage by __set_name__
-    name: typing.Optional[str] = None
+
+    def __init__(
+        self,
+        signature: Either(int, typing.Callable),
+        lift_args: Either(type(...), int, tuple) = ...,
+        flip: int = 0,
+        name: typing.Optional[str] = None,
+    ):
+        self.signature = Either(int, typing.Callable)(signature)
+        self.lift_args = Either(type(...), int, tuple)(lift_args)
+        self.flip = flip
+        self.name = name
 
     def __get__(self, obj, objtype=None):
         if obj is None:

--- a/fp/instances/lifts.py
+++ b/fp/instances/lifts.py
@@ -120,7 +120,7 @@ class Lift:
 
     def raw_lift(self, objtype: type, lift_args: tuple[int, ...]) -> typing.Callable:
         """
-        Lifted callable S' -> T' to be hom-typed.
+        Lifted callable (T A, ...) -> T A to be hom-typed.
         """
         method = self.raw(objtype)
         m = max(lift_args)
@@ -138,7 +138,7 @@ class Lift:
         return lifted
 
     def raw(self, objtype: type) -> typing.Callable:
-        """Callable S -> T to be lifted."""
+        """Callable (A, ...) -> A to be lifted."""
 
         def raw_bound_method(x, *xs):
             return getattr(x, self.name)(*xs)

--- a/fp/instances/lifts.py
+++ b/fp/instances/lifts.py
@@ -69,8 +69,14 @@ class Lift:
 
     def __get__(self, obj, objtype=None):
         if obj is None:
+            # unbound : Tx.method
             return self.hom(objtype)
+        elif objtype is not None:
+            # x.unary() : unary.__get__(x, Tx).__call__()
+            method = self.hom(objtype)
+            return Hom.partial(method, obj)
         else:
+            # bound : x.method
             method = self.hom(type(obj))
             return method(obj)
 

--- a/fp/instances/lifts.py
+++ b/fp/instances/lifts.py
@@ -81,14 +81,17 @@ class Lift:
         """
         Parse method signature specified on `objtype`.
         """
-        if callable(self.signature.data):
-            hom = self.signature.data(objtype)
+        signature = self.signature.data
+        if callable(signature):
+            hom = signature(objtype)
             return Hom(hom.src, hom.tgt)
-        elif type(self.signature.data) is int:
-            n = self.signature.data
+        elif signature == 1:
+            return Hom(objtype, objtype)
+        elif type(signature) is int:
+            n = signature
             return Hom(tuple([objtype] * n), objtype)
         else:
-            print("homtype", type(self.signature), objtype)
+            raise ValueError(f"Invalid signature, expected int | Callable[type, Hom]")
 
     def method(self):
         return LiftedMethod(self)
@@ -122,7 +125,8 @@ class Lift:
         def lifted(*xs):
             head = (x if f == 1 else f(x) for x, f in zip(xs, from_source))
             tail = (x for x in xs[m + 1 :])
-            y = self.to_target(method(*head, *tail))
+            y0 = method(*head, *tail)
+            y = self.to_target(y0)
             return y
 
         return lifted

--- a/fp/instances/lifts.py
+++ b/fp/instances/lifts.py
@@ -28,11 +28,11 @@ class Lift:
     applied to the arguments enumerated by the `lift_args` parameter, which defaults to
     `...` and can be given as `tuple[int, ...]` otherwise.
 
-    When `lift_args` is `...`, the method `name : (A, ...) -> A` only has arguments in `A`
-    and its signature can be given as an int (its _arity_), e.g.
+    When `lift_args` is `...` (the default), the method `name : (A, ...) -> A` only has
+    arguments in `A` and its signature can be given as an int (its _arity_), e.g.
 
         class MyMonoid:
-            __add__ = Lift(2, lift_args=...)
+            __add__ = Lift(2)
 
     Otherwise, because the method's signature is meant to depend on `A`, it is expected to
     be given as a `type -> Hom` callable:

--- a/fp/instances/wrap.py
+++ b/fp/instances/wrap.py
@@ -94,10 +94,9 @@ class Wrap(Type, metaclass=Functor):
         # --- Lift methods
         cls = Wrap_A.__class__
         for lift in Wrap_A._lifted_methods_:
-            homtype = lift.homtype(Wrap_A)
-            io.log(f"lifting {lift.name}: {type(lift)} {homtype}", v=2)
-            Wf = lift.method(Wrap_A)
-            setattr(Wrap_A, lift.name, Wf)
+            lift_fn = lift.method()
+            io.log(f"lifting {lift.name}: {type(lift)} {type(lift_fn)}", v=2)
+            setattr(Wrap_A, lift.name, lift.method())
         return Wrap_A
 
     def __init__(Wrap_A, *As): ...

--- a/fp/instances/wrap.py
+++ b/fp/instances/wrap.py
@@ -53,9 +53,15 @@ class Wrap(Type, metaclass=Functor):
 
     Object = WrapObject
 
-    @struct
     class Lift(LiftBase):
-        from_source = lambda x: x.data
+
+        @staticmethod
+        def from_source(x):
+            return x.data
+
+        @staticmethod
+        def to_target(x):
+            return x
 
     @classmethod
     def new(cls, A):

--- a/fp/instances/wrap.py
+++ b/fp/instances/wrap.py
@@ -1,5 +1,7 @@
 from fp.meta import Type, Functor, Functor
 from fp.cartesian import Hom, Prod
+from fp.instances import struct
+from fp.instances import Lift as LiftBase
 import fp.io as io
 
 from types import MethodType
@@ -46,36 +48,14 @@ class WrapObject(Functor.TopType, metaclass=Type):
 
 class Wrap(Type, metaclass=Functor):
     """
-    Type wrapper lifting selected methods to the container type.
-
-    The class method `lift` will iterate over the class attribute
-    `_lifted_methods_` to assign lifted methods on the wrapped type.
-
-    Attributes:
-    -----------
-        _lifted_methods_ (`list`):
-            A list of of triples `(name, signature, lift_args)` where
-                * name (`str`): name of the method to be lifted,
-                * signature (`Callable[type, Type]`) yielding lifted method type `signature(cls)`,
-                * lift_args (`int | tuple[int] | type(...)`) index of arguments to be unwrapped.
-
-            **Example**
-
-            .. code::
-
-                class StrWrapper(Wrap):
-
-                    _lifted_methods_ = [
-                        ('upper', lambda A: Hom(A, A), ...)
-                        ('isalnum', lambda A: Hom(A, Bool), ...)
-                        ('join', lambda A: Hom((A, List[A]), Bool), 0)
-                    ]
+    Type wrappers hoding a `.data` attribute.
     """
 
     Object = WrapObject
 
-    # lifts
-    _lifted_methods_ = []
+    @struct
+    class Lift(LiftBase):
+        from_source = lambda x: x.data
 
     @classmethod
     def new(cls, A):
@@ -89,17 +69,6 @@ class Wrap(Type, metaclass=Functor):
         msg += " ".join(str(A) for A in As[:2])
         io.log(msg, v=1)
         return Type.__new__(cls, *As)
-
-    def _post_new_(Wrap_A, A):
-        # --- Lift methods
-        cls = Wrap_A.__class__
-        for lift in Wrap_A._lifted_methods_:
-            lift_fn = lift.method()
-            io.log(f"lifting {lift.name}: {type(lift)} {type(lift_fn)}", v=2)
-            setattr(Wrap_A, lift.name, lift.method())
-        return Wrap_A
-
-    def __init__(Wrap_A, *As): ...
 
     @classmethod
     def join(cls, wwx):

--- a/fp/io/__init__.py
+++ b/fp/io/__init__.py
@@ -1,6 +1,6 @@
 from .exceptions import *
 from .asserts import asserts
-from .log import log, VERBOSITY, color
+from .log import log, warn, VERBOSITY, color
 from .cast import cast
 from .show import repr_method, str_method
 from .docs import document

--- a/fp/io/exceptions.py
+++ b/fp/io/exceptions.py
@@ -30,8 +30,7 @@ class CastError(Error):
 
 class ConstructorError(Error):
 
-    def __init__(self, name, T, As):
-        msg = f"\n\t{T}.new{As}"
+    def __init__(self, msg):
         super().__init__(msg)
 
 

--- a/fp/io/log.py
+++ b/fp/io/log.py
@@ -13,6 +13,10 @@ def log(text, v=0, prefix=None):
         print(color(prefix, v), color(text))
 
 
+def warn(text):
+    log(text, v=0, prefix="/!\\")
+
+
 def color(text, c=None):
 
     COLORS = [

--- a/fp/meta/constructor.py
+++ b/fp/meta/constructor.py
@@ -199,7 +199,6 @@ class Constructor(Kind):
                 elif T is Var:
                     As = tuple(A if A is not ... else "..." for A in As)
                 if issubclass(T, Var):
-                    io.log(f"Call {T}.new")
                     TA = T.new(*(A if A is not ... else "..." for A in As))
                 else:
                     TA = T.var()(*As)

--- a/fp/meta/constructor.py
+++ b/fp/meta/constructor.py
@@ -1,17 +1,50 @@
 from __future__ import annotations
 
+import functools
+from typing import Callable, Any
+from enum import Enum
+
+from colorama import Fore
+
 from .kind import Kind
 from .type import Type
 from .method import Method
 
-import functools
-
-from typing import Callable, Any
-
 import fp.io as io
 import fp.utils
 
-from colorama import Fore
+
+class ConstructorCall(Enum):
+    new = "new"
+    variable = "variable"
+    struct = "struct"
+    subclass = "subclass"
+
+
+def _calling_mode(*As, **kwargs) -> ConstructorCall:
+    """Check if arguments are unhashable class/struct definitions."""
+    # subclass definition calls: T(name, bases, dct)
+    if len(As) >= 3 and type(As[2]) is dict:
+        return ConstructorCall("subclass")
+
+    # struct definition : Struct(keys, values, name, bases, dct)
+    is_struct = len(As) >= 5 and type(As[4]) is dict
+    is_struct |= "dct" in kwargs
+    if is_struct:
+        return ConstructorCall("struct")
+
+    # variable constructor : T.new("A", ...)
+    if any(isinstance(A, (str, Var, type(...))) for A in As):
+        return ConstructorCall("variable")
+
+    # type constructor : T.new(*As)
+    return ConstructorCall("new")
+
+
+def _is_parameterized(*As):
+    """Check if arguments contain strings/ellipsis/type variables."""
+    is_var = any(isinstance(A, (str, Var, type(...))) for A in As)
+    return is_var
 
 
 class Constructor(Kind):
@@ -33,9 +66,8 @@ class Constructor(Kind):
             """
             Parse input variables to a type constructor.
 
-            Defaults to the identity, override to extend support for arguments
-            (e.g. support unhashable inputs, enforce equality of equivalent inputs,
-            ...).
+            Defaults to the identity, override to extend support for arguments.
+            (e.g. support unhashable inputs, enforce equality of equivalent inputs).
             """
             return As
 
@@ -45,7 +77,8 @@ class Constructor(Kind):
                 base = cls.Object
                 try:
                     name = cls._get_name_(*As)
-                except:
+                except Exception as e:
+                    io.warn(f"Could not compute {cls}._get_name_({As})")
                     name = "T As"
                 if isinstance(cls, Type):
                     return type(cls).__new__(cls, name, (base,), {})
@@ -65,7 +98,13 @@ class Constructor(Kind):
                     type(base)._post_new_(T, *base._tail_)
             return T
 
-        def _post_new_(TA, *As): ...
+        def _post_new_(TA, *As):
+            """Type initiliazation hook.
+
+            Override this method to configure a newly created type
+            without interfering with the metaclass and `new` logic.
+            """
+            ...
 
         def __init__(TA, *As): ...
 
@@ -118,11 +157,12 @@ class Constructor(Kind):
         new_ = functools.cache(new)
 
         def cached_new(cls, *xs, **ys):
-            try:
+            mode, Mode = _calling_mode(*xs, **ys), ConstructorCall
+            if mode == Mode("new") or mode == Mode("variable"):
                 # T(*As)
                 xs = cls._pre_new_(*xs)
                 return new_(cls, *xs, **ys)
-            except Exception as e:
+            elif mode == Mode("subclass") or mode == Mode("struct"):
                 # class MyT(T(*As), metaclass=T):
                 return new(cls, *xs, **ys)
 
@@ -130,44 +170,59 @@ class Constructor(Kind):
 
     @staticmethod
     def _new_(T: Constructor, *As: Any) -> Type:
-        """
-        Wrapper around T.new constructor to be referenced as T.__new__.
-        """
-        try:
-            if any(isinstance(A, (str, Var, type(...))) for A in As):
-                # action on type variables
-                if len(As) >= 3 and isinstance(As[2], dict):
-                    raise RuntimeError("")
+        """Defines `T.__new__` as a wrapper around `T.new`."""
+        mode, Mode = _calling_mode(*As), ConstructorCall
+
+        if mode == Mode("subclass"):
+            try:
+                io.log(f"Subclass {As[0]} -> {T}", v=2)
+                if hasattr(T, "_subclass_") and mode.name == "subclass":
+                    return T._subclass_(*As[:3])
+                TA = Type.__new__(T, *As)
+                base = As[1][0]
+                TA._head_ = base._head_
+                TA._tail_ = base._tail_
+                return TA
+            except Exception as err:
+                print(err)
+                raise io.ConstructorError(
+                    f"Could not create subclass {As[0]} of {T}.\n\n"
+                    "If you override T._subclass_(name, bases, dct), "
+                    "it must return a type."
+                )
+
+        if mode == Mode("variable"):
+            try:
+                io.log(f"Parameterised type: {T}({As})", v=2)
                 if T is not Var:
                     As = Var._read_vars_(As)
                 elif T is Var:
                     As = tuple(A if A is not ... else "..." for A in As)
                 if issubclass(T, Var):
+                    io.log(f"Call {T}.new")
                     TA = T.new(*(A if A is not ... else "..." for A in As))
                 else:
                     TA = T.var()(*As)
-            else:
-                # concrete action
-                TA = T.new(*As)
-            # post new
-            TA.__name__ = T._get_name_(*As)
-            TA._head_ = T
-            TA._tail_ = As
-            T._post_new_(TA, *As)
-            return TA
-        except Exception as e:
-            # subclass definition
-            io.log(f"_subclass_ {T}: {As[0]} -> {As[1]}", v=1)
-            is_def = len(As) >= 3 and type(As[0]) is str and type(As[2]) is dict
-            if hasattr(T, "_subclass_") and is_def:
-                return T._subclass_(*As[:3])
-            TA = Type.__new__(T, *As)
-            base = As[1][0]
-            TA._head_ = base._head_
-            TA._tail_ = base._tail_
-            return TA
-        except:
-            raise io.ConstructorError("new", T, As)
+
+            except Exception as err:
+                raise io.ConstructorError(
+                    f"Could not create parameterised type {T}({As})"
+                )
+
+        if mode == Mode("new"):
+            io.log(f"Concrete type: {T}({As})", v=2)
+            TA = T.new(*As)
+
+        if mode == Mode("struct"):
+            io.log(f"Struct type: {As[:2]}", v=2)
+            TA = T.new(*As)
+
+        # post new
+        TA.__name__ = T._get_name_(*As)
+        TA._head_ = T
+        TA._tail_ = As
+        T._post_new_(TA, *As)
+        return TA
 
     def var(T) -> Constructor:
         """
@@ -201,6 +256,10 @@ class Var(Type, metaclass=Constructor):
     _accessors_ = None
 
     class Object: ...
+
+    @classmethod
+    def new(cls, *As):
+        return super().new(*As)
 
     def _post_new_(A, name: str, *accessors: str):
         A._tail_ = None

--- a/fp/meta/type.py
+++ b/fp/meta/type.py
@@ -26,6 +26,8 @@ class Type(type, metaclass=Kind):
 
     def __new__(cls, name, bases=(), dct={}, head=None, tail=None):
         """Create a new type expression."""
+        if isinstance(name, type):
+            return cls._from_class_definition(name)
         T = super().__new__(cls, name, bases, dct)
         # expression tree for pattern matching
         T._head_ = name if isinstance(head, type(None)) else head
@@ -55,6 +57,16 @@ class Type(type, metaclass=Kind):
         T.shows = shows
         T.show = show
         return T
+
+    @classmethod
+    def _from_class_definition(cls, class_def: type) -> type:
+        # decorate a class definition
+        return cls.__new__(
+            cls,
+            class_def.__name__,
+            class_def.__bases__,
+            dict(class_def.__dict__),
+        )
 
     def __init__(self, *xs, **ys): ...
 

--- a/fp/tensors/backend.py
+++ b/fp/tensors/backend.py
@@ -8,28 +8,6 @@ from fp.instances import struct
 from .interfaces import Interface, INTERFACES, StatefulInterface
 
 
-@struct
-class LiftWrap(Lift):
-    """Lifts a method to the wrapper type."""
-
-    from_source = lambda x: x.data
-
-
-TENSOR_METHODS = [
-    #   # arithmetic methods
-    #   LiftWrap("__add__", 2),
-    #   LiftWrap("__sub__", 2),
-    #   LiftWrap("__mul__", 2),
-    #   LiftWrap("__truediv__", 2),
-    #   LiftWrap("__neg__", 1),
-    #   # reshapes
-    #   LiftWrap("flatten", 1),
-    #   LiftWrap("reshape", lambda T: Hom((T, tuple), T), 0, flip=1),
-]
-
-# ====== Backend: Wrap an interface ======
-
-
 class Backend(Ring, Wrap):
     """Functor wrapping the `Array` type of an `Interface` object.
 
@@ -57,13 +35,15 @@ class Backend(Ring, Wrap):
     """
 
     class Object(Wrap.Object):
-        __add__ = LiftWrap(2)
-        __sub__ = LiftWrap(2)
-        __mul__ = LiftWrap(2)
-        __neg__ = LiftWrap(1)
-        __truediv__ = LiftWrap(2)
-        flatten = LiftWrap(1)
-        reshape = LiftWrap(lambda T: Hom((T, tuple), T), lift_args=0, flip=1)
+        """Holds a `.data` attribute reference to an array."""
+
+        __add__ = Wrap.Lift(2)
+        __sub__ = Wrap.Lift(2)
+        __mul__ = Wrap.Lift(2)
+        __neg__ = Wrap.Lift(1)
+        __truediv__ = Wrap.Lift(2)
+        flatten = Wrap.Lift(1)
+        reshape = Wrap.Lift(lambda T: Hom((T, tuple), T), lift_args=0, flip=1)
 
     @classmethod
     def new(cls, api: Interface):

--- a/fp/tensors/backend.py
+++ b/fp/tensors/backend.py
@@ -49,7 +49,7 @@ class Backend(Ring, Wrap):
     def new(cls, api: Interface):
         # allow overriding of `api.Array` with Union for mocked api
         Array = cls._Array_ if hasattr(cls, "_Array_") else api.Array
-        B = super(cls, cls).new(Array)
+        B = super().new(Array)
         B._Array_ = Array
         B._interface_ = api
         return B

--- a/fp/tensors/backend.py
+++ b/fp/tensors/backend.py
@@ -56,7 +56,14 @@ class Backend(Ring, Wrap):
     provides the rest of the API in a more readable and pythonic way.
     """
 
-    _lifted_methods_ = TENSOR_METHODS
+    class Object(Wrap.Object):
+        __add__ = LiftWrap("__add__", 2).method()
+        __sub__ = LiftWrap("__sub__", 2).method()
+        __mul__ = LiftWrap("__mul__", 2).method()
+        __neg__ = LiftWrap("__neg__", 1).method()
+        __truediv__ = LiftWrap("__truediv__", 2).method()
+        flatten = LiftWrap("flatten", 1).method()
+        reshape = LiftWrap("reshape", lambda T: Hom((T, tuple), T), 0, flip=1).method()
 
     @classmethod
     def new(cls, api: Interface):

--- a/fp/tensors/backend.py
+++ b/fp/tensors/backend.py
@@ -16,15 +16,15 @@ class LiftWrap(Lift):
 
 
 TENSOR_METHODS = [
-    # arithmetic methods
-    LiftWrap("__add__", 2),
-    LiftWrap("__sub__", 2),
-    LiftWrap("__mul__", 2),
-    LiftWrap("__truediv__", 2),
-    LiftWrap("__neg__", 1),
-    # reshapes
-    LiftWrap("flatten", 1),
-    LiftWrap("reshape", lambda T: Hom((T, tuple), T), 0, flip=1),
+    #   # arithmetic methods
+    #   LiftWrap("__add__", 2),
+    #   LiftWrap("__sub__", 2),
+    #   LiftWrap("__mul__", 2),
+    #   LiftWrap("__truediv__", 2),
+    #   LiftWrap("__neg__", 1),
+    #   # reshapes
+    #   LiftWrap("flatten", 1),
+    #   LiftWrap("reshape", lambda T: Hom((T, tuple), T), 0, flip=1),
 ]
 
 # ====== Backend: Wrap an interface ======
@@ -57,13 +57,13 @@ class Backend(Ring, Wrap):
     """
 
     class Object(Wrap.Object):
-        __add__ = LiftWrap("__add__", 2).method()
-        __sub__ = LiftWrap("__sub__", 2).method()
-        __mul__ = LiftWrap("__mul__", 2).method()
-        __neg__ = LiftWrap("__neg__", 1).method()
-        __truediv__ = LiftWrap("__truediv__", 2).method()
-        flatten = LiftWrap("flatten", 1).method()
-        reshape = LiftWrap("reshape", lambda T: Hom((T, tuple), T), 0, flip=1).method()
+        __add__ = LiftWrap(2)
+        __sub__ = LiftWrap(2)
+        __mul__ = LiftWrap(2)
+        __neg__ = LiftWrap(1)
+        __truediv__ = LiftWrap(2)
+        flatten = LiftWrap(1)
+        reshape = LiftWrap(lambda T: Hom((T, tuple), T), lift_args=0, flip=1)
 
     @classmethod
     def new(cls, api: Interface):

--- a/fp/tensors/interfaces/jax_interface.py
+++ b/fp/tensors/interfaces/jax_interface.py
@@ -11,7 +11,7 @@ try:
     class JaxInterface(Interface):
         module = jax.numpy
         # array class and constructor
-        Array = jax.lib.xla_extension.ArrayImpl
+        Array = jax.numpy.ndarray
         asarray = jax.numpy.asarray
         # dtypes : jax.numpy.<dtype>(x)
         dtypes = DtypeTable()

--- a/fp/tensors/tens.py
+++ b/fp/tensors/tens.py
@@ -9,8 +9,14 @@ from fp.cartesian import Type, Hom
 from fp.instances import Ring
 import fp.io as io
 
+from .tensor import Tensor
+from .backend import Backend
+from .interfaces import StatefulInterface
 
-class Tens(Backend, Ring, metaclass=Functor):
+StatefulBackend = Backend(StatefulInterface.mock())
+
+
+class Tens(Backend, metaclass=Functor):
     """
     Typed tensor spaces.
 
@@ -26,31 +32,21 @@ class Tens(Backend, Ring, metaclass=Functor):
                     [ 4,  5]]
     """
 
+    _Array_ = Tensor._Array_
+
+    class Object(TensBase): ...
+
     @classmethod
     def new(cls, A):
-        class Tens_A:
-
-            shape = A
-            domain = Torus(A)
-
-        name = cls._get_name_(A)
-        Tens_A.__name__ = name
-        bases = (
-            Tens_A,
-            TensBase,
-        )
-        dct = dict(Tens_A.__dict__)
-        dct["shape"] = tuple(A)
-        dct["domain"] = Torus(A)
-        TA = Ring.__new__(cls, name, bases, dct)
-        io.log(("Tens new", TA, type(TA), type(TA) is cls), v=1)
-        return TA
+        Tens_A = super().new(StatefulInterface.mock())
+        Tens_A.shape = A
+        Tens_A.domain = A
+        io.log((cls, "new", Tens_A, A), v=1)
+        return Tens_A
 
     def _post_new_(Tens_A, A):
-        Backend._post_new_(Tens_A, Tensor._interface_)
-        Ring.__init__(Tens_A, Tens_A.__name__)
-        cls = Tens_A.__class__
-        io.log((cls, "_post_new_", Tens_A, A), v=1)
+        Tens_A.shape = A
+        Tens_A.domain = Torus(A)
 
     def __init__(cls, A, *xs, **ks): ...
 

--- a/fp/tensors/tens_base.py
+++ b/fp/tensors/tens_base.py
@@ -45,19 +45,19 @@ class TensBase(Tensor, metaclass=Ring):
 
     @classmethod
     def zeros(cls, **ks):
-        super().zeros(cls.shape, **ks)
+        return super().zeros(cls.shape, **ks)
 
     @classmethod
     def ones(cls, **ks):
-        super().ones(cls.shape, **ks)
+        return super().ones(cls.shape, **ks)
 
     @classmethod
     def randn(cls, **ks):
-        super().randn(cls.shape, **ks)
+        return super().randn(cls.shape, **ks)
 
     @classmethod
     def rand(cls, **ks):
-        super().rand(cls.shape, **ks)
+        return super().rand(cls.shape, **ks)
 
     @classmethod
     def range(cls):

--- a/fp/tensors/tens_base.py
+++ b/fp/tensors/tens_base.py
@@ -38,6 +38,7 @@ class TensBase(Tensor, metaclass=Ring):
         In general, if x : Tens(A) and y : Tens(B) then xy
         is of type Tens([*A, *B])
         """
+        cls = self._head_
         TA, TB = self.__class__, other.__class__
         TAB = cls([*TA.shape, *TB.shape])
         xy = Tensor.otimes(self, other)

--- a/fp/tensors/tensor.py
+++ b/fp/tensors/tensor.py
@@ -27,11 +27,6 @@ if HAS_JAX:
     @register_pytree_node_class
     class Jax(Backend(INTERFACES["jax"]), TensorBase):
 
-        @classmethod
-        def cast(cls, x):
-            if isinstance(x, jax.Array):
-                return cls(x)
-
         def tree_flatten(self):
             return ((self.data,), None)
 

--- a/tests/test_hom.py
+++ b/tests/test_hom.py
@@ -10,7 +10,71 @@ B = Type("B", (str,), {})
 HomObject = Hom.Object
 
 
-class TestHomObject: ...
+class TestHomObject:
+
+    class HomAB(HomObject):
+        src = int
+        tgt = str
+        arity = 1
+
+    class HomBA(HomObject):
+        src = str
+        tgt = int
+        arity = 1
+
+    class HomBAB(HomObject):
+        src = Type.Prod(str, int)
+        tgt = str
+        arity = 2
+
+    foo = HomBA(lambda s: len(s))
+    bar = HomAB(lambda n: "|" * n)
+    foobar = HomBAB(lambda s, n: s * n)
+
+    def test_eq(self):
+        assert self.bar == self.bar
+        assert self.foo != self.bar
+
+    def test_hash(self):
+        d = {self.bar: "bar", self.foo: "foo"}
+        assert len(d) == 2
+
+    ### source_type ###
+
+    def test_source_type_unary(self):
+        Tx, match_x = HomObject.source_type(self.foo, ("abc",))
+        Ty, match_y = HomObject.source_type(self.bar, (3,))
+        assert Tx is str and match_x is True
+        assert Ty is int and match_y is True
+
+    def test_source_type_binary(self):
+        Tx, match = HomObject.source_type(self.foobar, ("abc", 3))
+        assert match is True
+        assert Tx == Type.Prod(str, int)
+
+    def test_source_type_partial(self):
+        Tx, match = HomObject.source_type(self.foobar, ("abc",))
+        assert match is True
+        assert Tx == Type.Prod(
+            str,
+        )
+
+    ### target_type ###
+
+    def test_target_type_unary(self):
+        Ty = HomObject.target_type(self.foo, ("abc",))
+        assert Ty is int
+
+    def test_target_type_binary(self):
+        Ty = HomObject.target_type(self.foobar, ("abc", 2))
+        assert Ty is str
+
+    def test_target_type_partial(self):
+        # called by curryfication
+        self.foobar._head_ = Hom
+        Ty = HomObject.target_type(self.foobar, ("abc",))
+        assert Ty.arity == 1
+        assert (Ty.src, Ty.tgt) == (Type.Prod(int), str)
 
 
 class TestHom:

--- a/tests/test_hom.py
+++ b/tests/test_hom.py
@@ -39,6 +39,40 @@ class TestHomObject:
         d = {self.bar: "bar", self.foo: "foo"}
         assert len(d) == 2
 
+    ### application ###
+
+    def test_call(self):
+        foo_abc = self.foo("abc")
+        assert foo_abc == 3
+        bar_4 = self.bar(4)
+        assert bar_4 == "||||"
+
+    def test_lshift(self):
+        foo_x = self.foo << "x"
+        assert foo_x == 1
+
+    ### composition ###
+
+    @pytest.mark.xfail
+    def test_matmul_fail(self):
+        self.foo @ self.foo
+
+    def test_matmul(self):
+        self.foo._head_ = Hom
+        self.bar._head_ = Hom
+        foo_bar = self.foo @ self.bar
+        bar_foo = self.bar @ self.foo
+        assert (foo_bar.src, foo_bar.tgt) == (self.bar.src, self.foo.tgt)
+        assert (bar_foo.src, bar_foo.tgt) == (self.foo.src, self.bar.tgt)
+
+    def test_matmul_eval(self):
+        self.foo._head_ = Hom
+        self.bar._head_ = Hom
+        foo_bar = self.foo @ self.bar
+        bar_foo = self.bar @ self.foo
+        assert foo_bar(4) == 4
+        assert bar_foo("toto") == "||||"
+
     ### source_type ###
 
     def test_source_type_unary(self):

--- a/tests/test_hom.py
+++ b/tests/test_hom.py
@@ -39,6 +39,10 @@ class TestHom:
     def test_call_cast(self):
         assert self.bar(4) == B("||||")
 
+    def test_empty_call(self):
+        f = Hom((), int)(lambda: 1)
+        assert f() == 1
+
     def test_matmul_call(self):
         foobar = self.foo @ self.bar
         barfoo = self.bar @ self.foo

--- a/tests/test_tensor/_test_tensor.py
+++ b/tests/test_tensor/_test_tensor.py
@@ -16,6 +16,16 @@ class _TestTensor:
         x = self.T(tuple_x)
         assert tuple(x) == tuple_x
 
+    def test_flatten_unbound(self):
+        x = self.T(((0, 1), (2, 3)))
+        x_flat = self.T.flatten(x)
+        assert tuple(x_flat) == (0, 1, 2, 3)
+
+    def test_neg(self):
+        x = self.T((-1.0, 0.0, 1.0))
+        x = -x
+        assert tuple(i for i in x.data) == (1.0, 0.0, -1.0)
+
     def test_add_operator(self):
         x = self.T((0, 1, 2))
         y = self.T((3, 2, 1))

--- a/tests/test_tensor/_test_tensor.py
+++ b/tests/test_tensor/_test_tensor.py
@@ -21,6 +21,11 @@ class _TestTensor:
         x_flat = self.T.flatten(x)
         assert tuple(x_flat) == (0, 1, 2, 3)
 
+    def test_flatten_bound(self):
+        x = self.T(((0, 1), (2, 3)))
+        x_flat = x.flatten()
+        assert tuple(x_flat) == (0, 1, 2, 3)
+
     def test_neg(self):
         x = self.T((-1.0, 0.0, 1.0))
         x = -x

--- a/tests/test_tensor/_test_tensor.py
+++ b/tests/test_tensor/_test_tensor.py
@@ -21,7 +21,7 @@ class _TestTensor:
         y = self.T((3, 2, 1))
         assert tuple(x + y) == (3, 3, 3)
 
-    @pytest.mark.skip("__get__(obj) broken?")
+    @pytest.mark.skip("TODO with Lifts and Methods?")
     def test_add_bound(self):
         x = self.T((0, 1, 2))
         y = self.T((3, 2, 1))

--- a/tests/test_tensor/test_tens.py
+++ b/tests/test_tensor/test_tens.py
@@ -1,0 +1,21 @@
+from fp.tensors import Tens
+
+
+class TestTens:
+
+    T = Tens
+
+    def test_new(self):
+        T1 = self.T((2, 3))
+        assert isinstance(T1, self.T)
+        assert T1.shape == (2, 3)
+        assert hasattr(T1, "domain")
+
+    def test_zeros(self):
+        zeros1 = self.T((2, 3)).zeros()
+        assert zeros1.shape == (2, 3)
+
+    def test_range(self):
+        idx1 = self.T((2, 3)).range()
+        flattened = tuple(int(i) for i in idx1.data.flatten())
+        assert flattened == (0, 1, 2, 3, 4, 5)

--- a/tests/test_tensor/test_tens.py
+++ b/tests/test_tensor/test_tens.py
@@ -1,3 +1,4 @@
+import pytest
 from fp.tensors import Tens
 
 
@@ -6,16 +7,34 @@ class TestTens:
     T = Tens
 
     def test_new(self):
-        T1 = self.T((2, 3))
-        assert isinstance(T1, self.T)
-        assert T1.shape == (2, 3)
-        assert hasattr(T1, "domain")
+        T23 = self.T((2, 3))
+        assert isinstance(T23, self.T)
+        assert T23.shape == (2, 3)
+        assert hasattr(T23, "domain")
 
     def test_zeros(self):
-        zeros1 = self.T((2, 3)).zeros()
-        assert zeros1.shape == (2, 3)
+        zeros = self.T((2, 3)).zeros()
+        assert zeros.shape == (2, 3)
+
+    def test_ones(self):
+        ones = self.T((4,)).ones()
+        assert ones.shape == (4,)
 
     def test_range(self):
-        idx1 = self.T((2, 3)).range()
-        flattened = tuple(int(i) for i in idx1.data.flatten())
+        idx = self.T((2, 3)).range()
+        flattened = tuple(int(i) for i in idx.data.flatten())
         assert flattened == (0, 1, 2, 3, 4, 5)
+
+    @pytest.mark.skip("TODO: torch specific")
+    def test_randn(self):
+        gauss = self.T((2, 3)).randn()
+        assert gauss.shape == (2, 3)
+
+    @pytest.mark.skip("TODO: fix this, use outer")
+    def test_otimes(self):
+        R2 = self.T((2,))
+        lhs = R2((1, -1))
+        rhs = R2((1, -1))
+        expect = (1, -1, -1, 1)
+        result = lhs.otimes(rhs)
+        assert expect == tuple(int(i) for i in result.data.flatten())

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -1,0 +1,20 @@
+from fp.meta import Type
+
+
+def test_decorator():
+
+    @Type
+    class Obj:
+        x = 0
+
+    assert isinstance(Obj, Type)
+    assert Obj.x == 0
+
+
+def test_metaclass():
+
+    class Obj(metaclass=Type):
+        x = 0
+
+    assert isinstance(Obj, Type)
+    assert Obj.x == 0

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -1,5 +1,6 @@
 from fp.meta import Var
-from fp.instances import List, Int
+from fp.cartesian import Hom, Prod
+from fp.instances import List, Int, Str
 
 
 def test_substitute():
@@ -8,6 +9,16 @@ def test_substitute():
 
 def test_substitute_nested():
     assert List("A").substitute({"A": Int}) == List(Int)
+
+
+def test_substitute_hom():
+    assert Hom("A", "A").substitute({"A": Int}) == Hom(Int, Int)
+
+
+def test_substitute_prod():
+    assert Prod(Int, Str, Int) == Prod(Var("A"), Var("B"), Var("A")).substitute(
+        {"A": Int, "B": Str}
+    )
 
 
 def test_match():

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -1,0 +1,14 @@
+from fp.meta import Var
+from fp.instances import List, Int
+
+
+def test_substitute():
+    assert Var("A").substitute({"A": Int}) == Int
+
+
+def test_substitute_nested():
+    assert List("A").substitute({"A": Int}) == List(Int)
+
+
+def test_match():
+    assert List("A").match(List(List(Int)))["A"] == List(Int)


### PR DESCRIPTION
### Changes

- `Lift` are declared as python descriptors
- The `Backend` constructor declares add, etc. as Lifts in its `Object` base type

### TODOs

- Circular imports `Lift -> Struct -> List -> Monoid, Int` prevent from declaring lifts in fp/instances/algebra.py
- Lifts could accept a more generic output type. 

   For now, this usage of the descriptor protocol can still serve as model for `Method` and `ClassMethod` bases for type-parameterized methods 