### PR TITLE
Feat: Struct field setters

### DIFF
--- a/fp/base/struct.py
+++ b/fp/base/struct.py
@@ -150,7 +150,12 @@ class StructObject(metaclass=Type):
             yield k, getattr(self, k)
 
     def __eq__(self, other):
+        if type(other) != type(self):
+            return False
         return all(x == y for x, y in zip(self.values(), other.values()))
+
+    def __hash__(self):
+        return id(self)
 
     def __getitem__(self, k):
         if isinstance(k, int):

--- a/fp/base/struct.py
+++ b/fp/base/struct.py
@@ -155,11 +155,9 @@ class StructObject(metaclass=Type):
     def __repr__(self):
         return showStruct(self)
 
-    def pull(self, keys):
-        if isinstance(keys, tuple):
-            xs = (getattr(self, k) for k in keys)
-            values = tuple((type(x), x) for x in xs)
-            return Struct(keys, values)(*xs)
+    def pull(self, Super: Type):
+        xs = (getattr(self, k) for k in Super._keys_)
+        return Super(*xs)
 
     def map(self, **fs):
         targets = []

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -1,0 +1,51 @@
+import pytest
+import fp
+
+
+class TestStruct:
+
+    @fp.struct
+    class Person:
+        name: fp.Str
+        number: fp.List(fp.Int)
+        job: fp.Str = "Pizzaiolo"
+
+    @pytest.fixture(scope="class")
+    def joe(self):
+        return self.Person("joe", [0, 4, 3, 2])
+
+    @pytest.fixture(scope="class")
+    def jack(self):
+        return self.Person("jack", [0, 1, 2, 3], "Plumber")
+
+    def test_attributes_default(self, joe):
+        assert joe.name == "joe"
+        assert joe.number == [0, 4, 3, 2]
+        assert joe.job == "Pizzaiolo"
+
+    def test_attributes_no_default(self, jack):
+        assert jack.name == "jack"
+        assert jack.job == "Plumber"
+
+    def test_field_getter(self):
+        assert self.Person.name.src == self.Person
+        assert self.Person.name.tgt == fp.Str
+
+    def test_field_setter(self):
+        assert self.Person.name.set.src == fp.Prod(fp.Str, self.Person)
+        assert self.Person.name.set.tgt == self.Person
+
+    def test_field_putter(self):
+        assert self.Person.number.set.src == fp.Prod(fp.List(fp.Int), self.Person)
+        assert self.Person.number.set.tgt == self.Person
+
+    def test_get(self, joe):
+        assert self.Person.job(joe) == "Pizzaiolo"
+
+    def test_set(self, jack):
+        jack2 = self.Person.job.set("Rock star")(jack)
+        assert jack.job == "Plumber" and jack2.job == "Rock star"
+
+    def test_put(self, jack):
+        self.Person.job.put("Rock star")(jack)
+        assert jack.job == "Rock star"

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -10,6 +10,10 @@ class TestStruct:
         number: fp.List(fp.Int)
         job: fp.Str = "Pizzaiolo"
 
+    @fp.struct
+    class Chiller:
+        name: fp.Str
+
     @pytest.fixture(scope="class")
     def joe(self):
         return self.Person("joe", [0, 4, 3, 2])
@@ -49,3 +53,8 @@ class TestStruct:
     def test_put(self, jack):
         self.Person.job.put("Rock star")(jack)
         assert jack.job == "Rock star"
+
+    def test_pull(self, jack):
+        retired_jack = jack.pull(self.Chiller)
+        assert isinstance(retired_jack, self.Chiller)
+        assert retired_jack.name == "jack"


### PR DESCRIPTION
### Changes

- Struct fields now inherits from `Hom(S, Val)`
- Struct fields have `.set` and `.put` properties, of signature `Val -> S -> S`
- Structs implement `__eq__`
- `.pull(Supertype)` is fixed

### Todo 

- friendlier updates, mimicking the dict methods. 